### PR TITLE
Add Package-Requires header for ELPA installations

### DIFF
--- a/show-css.el
+++ b/show-css.el
@@ -7,6 +7,7 @@
 ;; Created: 1st February 2013
 ;; Keywords: hypermedia
 ;; URL: https://github.com/smmcg/showcss-mode
+;; Package-Requires: ((dom "1.0.1"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;


### PR DESCRIPTION
When installing this package from [MELPA](http://melpa.milkbox.net/) (or any other ELPA repository in which it might be found) then `dom` should also be installed. This commit adds the corresponding `Package-Requires` header to install it.
